### PR TITLE
Feat/comparison self evaluation backend

### DIFF
--- a/backend/prisma/migrations/20250630114324_add_configured_criterion_to_self_evaluation_item/migration.sql
+++ b/backend/prisma/migrations/20250630114324_add_configured_criterion_to_self_evaluation_item/migration.sql
@@ -1,0 +1,20 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_SelfEvaluationItem" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "evaluationId" INTEGER NOT NULL,
+    "criterionId" INTEGER NOT NULL,
+    "configuredCriterionId" INTEGER,
+    "score" INTEGER NOT NULL,
+    "justification" TEXT NOT NULL,
+    "scoreDescription" TEXT,
+    CONSTRAINT "SelfEvaluationItem_evaluationId_fkey" FOREIGN KEY ("evaluationId") REFERENCES "SelfEvaluation" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "SelfEvaluationItem_criterionId_fkey" FOREIGN KEY ("criterionId") REFERENCES "Criterion" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "SelfEvaluationItem_configuredCriterionId_fkey" FOREIGN KEY ("configuredCriterionId") REFERENCES "ConfiguredCriterion" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_SelfEvaluationItem" ("criterionId", "evaluationId", "id", "justification", "score", "scoreDescription") SELECT "criterionId", "evaluationId", "id", "justification", "score", "scoreDescription" FROM "SelfEvaluationItem";
+DROP TABLE "SelfEvaluationItem";
+ALTER TABLE "new_SelfEvaluationItem" RENAME TO "SelfEvaluationItem";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -182,6 +182,8 @@ model ConfiguredCriterion {
   track    Track          @relation("TrackConfiguredCriteria", fields: [trackId], references: [id])
   unit     Unit           @relation("UnitConfiguredCriteria", fields: [unitId], references: [id])
   position Position       @relation("PositionConfiguredCriteria", fields: [positionId], references: [id])
+
+  selfEvaluationItems SelfEvaluationItem[]
 }
 
 
@@ -218,16 +220,19 @@ model SelfEvaluation {
 }
 
 model SelfEvaluationItem {
-  id               Int     @id @default(autoincrement())
-  evaluationId     Int
-  criterionId      Int
-  score            Int
-  justification    String
-  scoreDescription String?
+  id                   Int     @id @default(autoincrement())
+  evaluationId         Int
+  criterionId          Int
+  configuredCriterionId Int?
+  score                Int
+  justification        String
+  scoreDescription     String?
 
-  evaluation SelfEvaluation @relation(fields: [evaluationId], references: [id])
-  criterion  Criterion      @relation(fields: [criterionId], references: [id])
+  evaluation          SelfEvaluation     @relation(fields: [evaluationId], references: [id])
+  criterion           Criterion          @relation(fields: [criterionId], references: [id])
+  configuredCriterion ConfiguredCriterion? @relation(fields: [configuredCriterionId], references: [id])
 }
+
 
 model Project {
   id          Int                     @id @default(autoincrement())

--- a/backend/src/collaborator/self-evaluation/self-evaluation.controller.ts
+++ b/backend/src/collaborator/self-evaluation/self-evaluation.controller.ts
@@ -60,4 +60,16 @@ export class SelfEvaluationController {
     const userId = req.user.userId;
     return this.selfEvaluationService.getAvailableCriteria(userId);
   }
+
+  @Get('grouped/:cycleId')
+  @ApiOperation({ summary: 'Critérios e respostas agrupados por grupo de critérios de um ciclo anterior' })
+  @UseGuards(JwtAuthGuard)
+  async getGroupedByCycle(
+    @Param('cycleId', ParseIntPipe) cycleId: number,
+    @Req() req: any
+  ) {
+    const userId = req.user.userId; // conforme seu token
+    return this.selfEvaluationService.getGroupedEvaluation(cycleId, userId);
+  }
+
 }

--- a/backend/src/collaborator/self-evaluation/self-evaluation.controller.ts
+++ b/backend/src/collaborator/self-evaluation/self-evaluation.controller.ts
@@ -14,7 +14,7 @@ import {
 import { SelfEvaluationService } from './self-evaluation.service';
 import { CreateSelfEvaluationDto } from './dto/create-self-evaluation.dto';
 import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
-import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiParam} from '@nestjs/swagger';
 import { UpdateSelfEvaluationDto } from './dto/update-self-evaluation.dto';
 
 @ApiTags('Self Evaluation')
@@ -70,6 +70,14 @@ export class SelfEvaluationController {
   ) {
     const userId = req.user.userId; // conforme seu token
     return this.selfEvaluationService.getGroupedEvaluation(cycleId, userId);
+  }
+
+
+  @Get('user/:userId')
+  @ApiOperation({ summary: 'Listar todas as autoavaliações anteriores de um usuário' })
+  @ApiParam({ name: 'userId', type: Number })
+  getByUserId(@Param('userId', ParseIntPipe) userId: number) {
+    return this.selfEvaluationService.getByUserId(userId);
   }
 
 }

--- a/backend/src/collaborator/self-evaluation/self-evaluation.service.ts
+++ b/backend/src/collaborator/self-evaluation/self-evaluation.service.ts
@@ -26,64 +26,75 @@ export class SelfEvaluationService {
   }
 
   async create(userId: number, dto: CreateSelfEvaluationDto) {
-    try {
-      // Verifica se já existe avaliação do usuário no ciclo informado
-      const existing = await this.prisma.selfEvaluation.findFirst({
-        where: {
-          userId,
-          cycleId: dto.cycleId,
-        },
-      });
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
 
-      if (existing) {
-        throw new ConflictException('Autoavaliação já existe para este ciclo');
-      }
+    if (!user || !user.positionId || !user.unitId || !user.trackId) {
+      throw new Error("Usuário incompleto");
+    }
 
-      // Validação dos critérios enviados
-      const allCriterionIds = dto.items.map((i) => i.criterionId);
-      const existingCriteria = await this.prisma.criterion.findMany({
-        where: { id: { in: allCriterionIds } },
-      });
+    const existing = await this.prisma.selfEvaluation.findFirst({
+      where: { userId, cycleId: dto.cycleId },
+    });
 
-      const validIds = new Set(existingCriteria.map((c) => c.id));
-      const invalid = allCriterionIds.filter((id) => !validIds.has(id));
+    if (existing) {
+      throw new ConflictException("Autoavaliação já existe para este ciclo");
+    }
 
-      if (invalid.length > 0) {
-        throw new Error(`Critérios inválidos: ${invalid.join(', ')}`);
-      }
+    const itemsToCreate = await Promise.all(
+      dto.items.map(async (item) => {
+        const configured = await this.prisma.configuredCriterion.findFirst({
+          where: {
+            criterionId: item.criterionId,
+            positionId: user.positionId!,
+            unitId: user.unitId!,
+            trackId: user.trackId!,
+          },
+        });
 
-      // Criação da avaliação
-      return await this.prisma.selfEvaluation.create({
-        data: {
-          userId,
-          cycleId: dto.cycleId,
-          items: {
-            createMany: {
-              data: dto.items.map((item) => ({
-                criterionId: item.criterionId,
-                score: item.score,
-                justification: item.justification,
-                scoreDescription: this.getScoreDescription(item.score),
-              })),
-            },
+        if (!configured) {
+          throw new Error(`Critério ${item.criterionId} não configurado para esse usuário`);
+        }
+
+        return {
+          criterionId: item.criterionId,
+          configuredCriterionId: configured.id,
+          score: item.score,
+          justification: item.justification,
+          scoreDescription: this.getScoreDescription(item.score),
+        };
+      })
+    );
+
+    return await this.prisma.selfEvaluation.create({
+      data: {
+        userId,
+        cycleId: dto.cycleId,
+        items: {
+          createMany: {
+            data: itemsToCreate,
           },
         },
-        include: {
-          items: true,
-        },
-      });
-    } catch (error) {
-      console.error('Erro ao criar autoavaliação:', error);
-      throw error;
-    }
+      },
+      include: {
+        items: true,
+      },
+    });
   }
-
 
   async findByUser(where: { userId: number; cycleId?: number }) {
     const evaluations = await this.prisma.selfEvaluation.findMany({
       where,
       include: {
-        items: true,
+        items: {
+          include: {
+            criterion: true,
+            configuredCriterion: {
+              include: {
+                group: true,
+              },
+            },
+          },
+        },
         cycle: true,
       },
     });
@@ -91,52 +102,83 @@ export class SelfEvaluationService {
     return evaluations.map((evaluation) => {
       const now = new Date();
       const isEditable = evaluation.cycle.endDate > now;
+
+      const itemsWithGroup = evaluation.items.map((item) => ({
+        id: item.id,
+        criterionId: item.criterionId,
+        score: item.score,
+        justification: item.justification,
+        scoreDescription: item.scoreDescription,
+        group: item.configuredCriterion?.group
+          ? {
+              id: item.configuredCriterion.group.id,
+              name: item.configuredCriterion.group.name,
+            }
+          : null,
+      }));
+
       return {
         ...evaluation,
         isEditable,
+        items: itemsWithGroup,
       };
     });
   }
 
-
   async update(id: number, dto: UpdateSelfEvaluationDto) {
-    const { cycleId, items } = dto;
-
-    if (items && items.length > 0) {
-      // Valida se os critérios existem
-      const allCriterionIds = items.map((i) => i.criterionId);
-      const existingCriteria = await this.prisma.criterion.findMany({
-        where: { id: { in: allCriterionIds } },
-      });
-
-      const validIds = new Set(existingCriteria.map((c) => c.id));
-      const invalid = allCriterionIds.filter((id) => !validIds.has(id));
-
-      if (invalid.length > 0) {
-        throw new Error(`Critérios inválidos: ${invalid.join(', ')}`);
-      }
+    if (!dto.items || dto.items.length === 0) {
+      throw new Error("Nenhum item de avaliação recebido.");
     }
 
-    // Atualiza avaliação e substitui os itens
+    const evaluation = await this.prisma.selfEvaluation.findUnique({
+      where: { id },
+      include: { user: true },
+    });
+
+    if (!evaluation || !evaluation.user?.positionId || !evaluation.user?.unitId || !evaluation.user?.trackId) {
+      throw new Error("Usuário incompleto ou avaliação inexistente");
+    }
+
+    const itemsToCreate = await Promise.all(
+      dto.items.map(async (item) => {
+        const configured = await this.prisma.configuredCriterion.findFirst({
+          where: {
+            criterionId: item.criterionId,
+            positionId: evaluation.user.positionId!,
+            unitId: evaluation.user.unitId!,
+            trackId: evaluation.user.trackId!,
+          },
+        });
+
+        if (!configured) {
+          throw new Error(`Critério ${item.criterionId} não configurado`);
+        }
+
+        return {
+          criterionId: item.criterionId,
+          configuredCriterionId: configured.id,
+          score: item.score,
+          justification: item.justification,
+          scoreDescription: this.getScoreDescription(item.score),
+        };
+      })
+    );
+
     return this.prisma.selfEvaluation.update({
       where: { id },
       data: {
-        ...(cycleId && { cycleId }),
-        ...(items && {
-          items: {
-            deleteMany: {},
-            create: items.map((item) => ({
-              criterionId: item.criterionId,
-              score: item.score,
-              justification: item.justification,
-              scoreDescription: this.getScoreDescription(item.score),
-            })),
-          },
-        }),
+        items: {
+          deleteMany: {},
+          create: itemsToCreate,
+        },
       },
-      include: { items: true },
+      include: {
+        items: true,
+      },
     });
   }
+
+
 
   async delete(id: number) {
     try {

--- a/backend/src/collaborator/self-evaluation/self-evaluation.service.ts
+++ b/backend/src/collaborator/self-evaluation/self-evaluation.service.ts
@@ -291,6 +291,44 @@ export class SelfEvaluationService {
     return result.sort((a, b) => a.groupName.localeCompare(b.groupName));
   }
 
+  async getByUserId(userId: number) {
+    const evaluations = await this.prisma.selfEvaluation.findMany({
+      where: { userId },
+      include: {
+        cycle: true,
+        items: {
+          include: {
+            criterion: true,
+            configuredCriterion: {
+              include: {
+                group: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        cycle: { startDate: 'desc' },
+      },
+    });
+
+    return evaluations.map(evaluation => ({
+      evaluationId: evaluation.id,
+      cycle: {
+        id: evaluation.cycle.id,
+        name: evaluation.cycle.name,
+        startDate: evaluation.cycle.startDate,
+        endDate: evaluation.cycle.endDate,
+      },
+      items: evaluation.items.map(item => ({
+        criterionId: item.criterion.id,
+        title: item.criterion.name,
+        group: item.configuredCriterion?.group?.name ?? null,
+        score: item.score,
+        justification: item.justification,
+      })),
+    }));
+  }
 
 
 

--- a/backend/src/evaluation-cycle/evaluation-cycle.controller.ts
+++ b/backend/src/evaluation-cycle/evaluation-cycle.controller.ts
@@ -13,4 +13,9 @@ export class EvaluationCycleController {
   async getActiveCycle() {
     return this.evaluationCycleService.findActiveCycle();
   }
+
+  @Get('closed')
+  getClosedCycles() {
+    return this.evaluationCycleService.getClosedCycles();
+  }
 }

--- a/backend/src/evaluation-cycle/evaluation-cycle.service.ts
+++ b/backend/src/evaluation-cycle/evaluation-cycle.service.ts
@@ -11,4 +11,23 @@ export class EvaluationCycleService {
       where: { status: 'IN_PROGRESS' },
     });
   }
+ 
+  async getClosedCycles() {
+    const activeCycle = await this.findActiveCycle();
+
+    return this.prisma.evaluationCycle.findMany({
+      where: {
+        id: {
+          not: activeCycle?.id, // Exclui o ativo
+        },
+        startDate: {
+          lt: activeCycle?.startDate, // Só os anteriores
+        },
+      },
+      orderBy: {
+        startDate: 'desc',
+      },
+    });
+  }
 }
+

--- a/frontend/src/components/ComparisonEvaluationForm/ComparisonEvaluationForm.tsx
+++ b/frontend/src/components/ComparisonEvaluationForm/ComparisonEvaluationForm.tsx
@@ -1,5 +1,5 @@
 import EvaluationComparisonItem from './ComparisonEvaluationItem';
-import ScoreBox from '../ScoreBox';
+import ScoreBoxComparison from './ScoreBoxComparison';
 import type { EvaluationComparisonItemData } from '../../types/evaluationComparison';
 
 interface Props {
@@ -14,10 +14,10 @@ const EvaluationComparisonForm = ({ title, criteria }: Props) => {
   return (
     <div className="bg-white rounded-xl shadow p-6 w-full">
       <div className="flex justify-between items-center mb-6">
-        <h3 className="text-sm font-semibold text-green-main">{title}</h3>
+        <h3 className="text-bg font-semibold text-green-main">{title}</h3>
         <div className="flex gap-4">
-          <ScoreBox score={avgFinal} />
-          <ScoreBox score={avgSelf} />
+          <ScoreBoxComparison score={avgSelf} type='self-box' />
+          <ScoreBoxComparison score={avgFinal} type="final-box" />
         </div>
       </div>
 

--- a/frontend/src/components/ComparisonEvaluationForm/ComparisonEvaluationForm.tsx
+++ b/frontend/src/components/ComparisonEvaluationForm/ComparisonEvaluationForm.tsx
@@ -1,18 +1,15 @@
 import EvaluationComparisonItem from './ComparisonEvaluationItem';
 import ScoreBox from '../ScoreBox';
-import type { EvaluationComparisonFormProps } from '../../types/evaluationComparison';
+import type { EvaluationComparisonItemData } from '../../types/evaluationComparison';
 
-const EvaluationComparisonForm = ({ title, criteria }: EvaluationComparisonFormProps) => {
-  const selfScores = [3.5, 4.0, 3.0];
-  const finalScores = [4.0, 4.0, 4.0];
-  const justifications = [
-    'Me mostrei resiliente em situações complicadas',
-    'Busquei apoio e mantive consistência',
-    'Contribuí na organização de entregas',
-  ];
+interface Props {
+  title: string;
+  criteria: EvaluationComparisonItemData[];
+}
 
-  const avgSelf = selfScores.reduce((s, v) => s + v, 0) / criteria.length;
-  const avgFinal = finalScores.reduce((s, v) => s + v, 0) / criteria.length;
+const EvaluationComparisonForm = ({ title, criteria }: Props) => {
+  const avgSelf = criteria.reduce((sum, c) => sum + (c.selfScore ?? 0), 0) / criteria.length;
+  const avgFinal = criteria.reduce((sum, c) => sum + (c.finalScore ?? 0), 0) / criteria.length;
 
   return (
     <div className="bg-white rounded-xl shadow p-6 w-full">
@@ -30,11 +27,9 @@ const EvaluationComparisonForm = ({ title, criteria }: EvaluationComparisonFormP
             key={idx}
             index={idx + 1}
             title={c.title}
-            selfScore={selfScores[idx]}
-            finalScore={finalScores[idx]}
-            justification={justifications[idx]}
-            setSelfScore={() => {}}
-            setJustification={() => {}}
+            selfScore={c.selfScore}
+            finalScore={c.finalScore}
+            justification={c.justification}
           />
         ))}
       </div>

--- a/frontend/src/components/ComparisonEvaluationForm/ComparisonEvaluationItem.tsx
+++ b/frontend/src/components/ComparisonEvaluationForm/ComparisonEvaluationItem.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { FaChevronUp, FaChevronDown } from 'react-icons/fa';
 import type { EvaluationComparisonItemProps } from '../../types/evaluationComparison';
 import StarRatingReadOnly from '../StarRatingReadOnly';
-import ScoreBox from '../ScoreBox';
+import ScoreBoxComparison from './ScoreBoxComparison';
 
 const EvaluationComparisonItem = ({
   index,
@@ -23,12 +23,12 @@ const EvaluationComparisonItem = ({
           <p className="font-semibold text-gray-800">{title}</p>
         </div>
         <div className="flex items-center gap-3">
-          <ScoreBox score={finalScore} />
-          <ScoreBox score={selfScore}/>
+          <ScoreBoxComparison score={selfScore} type="self-text" />
+          <ScoreBoxComparison score={finalScore} type="final-text" />
           <button onClick={() => setIsOpen(!isOpen)}>
             {isOpen ? <FaChevronUp /> : <FaChevronDown />}
           </button>
-        </div>
+        </div> 
       </div>
 
       {isOpen && (

--- a/frontend/src/components/ComparisonEvaluationForm/EvaluationComparisonGroupList.tsx
+++ b/frontend/src/components/ComparisonEvaluationForm/EvaluationComparisonGroupList.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import axios from "axios";
+import EvaluationComparisonForm from "./ComparisonEvaluationForm";
+import { useAuth } from "../../context/AuthContext";
+import type { TrackWithGroups } from "../../types/selfEvaluation";
+import type { SubmittedSelfEvaluationItem } from "../../types/evaluationComparison";
+
+interface Props {
+  trackData: TrackWithGroups;
+  cycleId: number;
+}
+
+const EvaluationComparisonGroupList = ({ trackData, cycleId }: Props) => {
+  const { token } = useAuth();
+  const [answers, setAnswers] = useState<SubmittedSelfEvaluationItem[]>([]);
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        const response = await axios.get(`http://localhost:3000/self-evaluation?cycleId=${cycleId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+
+        const current = response.data.find((e: any) => e.cycle.id === cycleId);
+        if (current) {
+          setAnswers(current.items);
+        }
+      } catch (err) {
+        console.error("Erro ao buscar ciclo antigo:", err);
+      }
+    };
+
+    fetch();
+  }, [token, cycleId]);
+
+  const grouped = trackData.CriterionGroup.map((group) => {
+    const items = group.configuredCriteria.map((cc) => {
+      const item = answers.find(
+        (i) => i.criterionId === cc.criterion.id && i.group?.id === group.id
+      );
+
+      return {
+        title: cc.criterion.displayName,
+        selfScore: item?.score ?? 0,
+        finalScore: 0,
+        justification: item?.justification ?? "",
+      };
+    });
+
+    return (
+      <EvaluationComparisonForm
+        key={group.id}
+        title={group.name}
+        criteria={items}
+      />
+    );
+  });
+
+  return <div className="p-3 bg-[#f1f1f1] space-y-6">{grouped}</div>;
+};
+
+export default EvaluationComparisonGroupList;

--- a/frontend/src/components/ComparisonEvaluationForm/EvaluationCycleSelector.tsx
+++ b/frontend/src/components/ComparisonEvaluationForm/EvaluationCycleSelector.tsx
@@ -1,12 +1,47 @@
-const EvaluationCycleSelector = ({ currentCycle }: { currentCycle: string }) => {
+import { useEffect, useState } from "react";
+
+interface Props {
+  currentCycle: string;
+  onChange: (cycleId: number, cycleName: string) => void;
+}
+
+interface Cycle {
+  id: number;
+  name: string;
+}
+
+const EvaluationCycleSelector = ({ currentCycle, onChange }: Props) => {
+  const [cycles, setCycles] = useState<Cycle[]>([]);
+
+  useEffect(() => {
+    const fetchCycles = async () => {
+      try {
+        const res = await fetch("http://localhost:3000/evaluation-cycle/closed");
+        const data = await res.json();
+        setCycles(data);
+      } catch (err) {
+        console.error("Erro ao buscar ciclos fechados:", err);
+      }
+    };
+
+    fetchCycles();
+  }, []);
+
   return (
     <select
       defaultValue={currentCycle}
       className="border border-gray-300 rounded px-3 py-1 text-sm text-gray-700"
+      onChange={(e) => {
+        const selected = cycles.find(c => c.name === e.target.value);
+        if (selected) onChange(selected.id, selected.name);
+      }}
     >
-      <option value="2024.2">2024.2</option>
-      <option value="2024.1">2024.1</option>
-      <option value="2023.2">2023.2</option>
+      <option disabled value="">Selecione um ciclo</option>
+      {cycles.map((cycle) => (
+        <option key={cycle.id} value={cycle.name}>
+          {cycle.name}
+        </option>
+      ))}
     </select>
   );
 };

--- a/frontend/src/components/ComparisonEvaluationForm/ScoreBoxComparison.tsx
+++ b/frontend/src/components/ComparisonEvaluationForm/ScoreBoxComparison.tsx
@@ -1,0 +1,31 @@
+interface ScoreBoxComparisonProps {
+  score?: number;
+  type: "self-box" | "final-box" | "self-text" | "final-text";
+}
+
+const ScoreBoxComparison = ({ score, type }: ScoreBoxComparisonProps) => {
+  let bg = "#E6E6E6";
+  let color = "#1D1D1D";
+
+  if (type === "self-box") {
+    bg = "#E6E6E6";
+    color = "#08605F";
+  } else if (type === "final-box") {
+    bg = '#08605F';
+    color = "#FFFFFF";
+  } else if (type === "final-text") {
+    bg = "#E6E6E6";
+    color = "#08605F";
+  }
+
+  return (
+    <div
+      className={`w-[37px] h-[25px] rounded-[4px] flex items-center justify-center text-sm font-bold`}
+      style={{ backgroundColor: bg, color }}
+    >
+      {score ?? "-"}
+    </div>
+  );
+};
+
+export default ScoreBoxComparison;

--- a/frontend/src/components/SelfEvaluationForm/SelfEvaluationGroupList.tsx
+++ b/frontend/src/components/SelfEvaluationForm/SelfEvaluationGroupList.tsx
@@ -54,7 +54,6 @@ const SelfEvaluationGroupList = ({ trackData, cycleId }: Props) => {
   };
 
   useEffect(() => {
-    // Verificar se já existe avaliação para esse ciclo
     const fetch = async () => {
       try {
         const response = await axios.get(`http://localhost:3000/self-evaluation?cycleId=${cycleId}`, {
@@ -65,6 +64,27 @@ const SelfEvaluationGroupList = ({ trackData, cycleId }: Props) => {
         if (current) {
           setSelfEvaluationId(current.id);
           setIsUpdate(true);
+
+          const groupedRatings: Record<number, number[]> = {};
+          const groupedJustifications: Record<number, string[]> = {};
+
+          trackData.CriterionGroup.forEach((group) => {
+            groupedRatings[group.id] = [];
+            groupedJustifications[group.id] = [];
+
+            group.configuredCriteria.forEach((cc) => {
+              const answer = current.items.find(
+                (item: any) =>
+                  item.criterionId === cc.criterion.id && item.group?.id === group.id
+              );
+
+              groupedRatings[group.id].push(answer?.score ?? 0);
+              groupedJustifications[group.id].push(answer?.justification ?? "");
+            });
+          });
+
+          setRatings(groupedRatings);
+          setJustifications(groupedJustifications);
         }
       } catch (e) {
         console.error("Erro ao verificar avaliação existente:", e);
@@ -72,7 +92,8 @@ const SelfEvaluationGroupList = ({ trackData, cycleId }: Props) => {
     };
 
     fetch();
-  }, [token, cycleId]);
+  }, [token, cycleId, trackData]);
+
 
   useEffect(() => {
     const submitSelfEvaluation = async () => {

--- a/frontend/src/layouts/ComparisonLayout.tsx
+++ b/frontend/src/layouts/ComparisonLayout.tsx
@@ -21,6 +21,7 @@ const ComparisonLayout = () => {
             <NavLink
               key={path}
               to={path}
+              end={path === "/collaborator/evaluation-comparison"}
               className={({ isActive }) =>
                 isActive
                   ? "text-md font-bold text-green-main border-b-2 border-green-main pb-1"

--- a/frontend/src/layouts/ComparisonLayout.tsx
+++ b/frontend/src/layouts/ComparisonLayout.tsx
@@ -1,4 +1,5 @@
 import { NavLink, Outlet } from "react-router-dom";
+import { useState } from "react";
 import EvaluationCycleSelector from "../components/ComparisonEvaluationForm/EvaluationCycleSelector";
 
 const tabs = [
@@ -9,12 +10,22 @@ const tabs = [
 ];
 
 const ComparisonLayout = () => {
+  const [selectedCycleId, setSelectedCycleId] = useState<number | null>(null);
+  const [selectedCycleName, setSelectedCycleName] = useState<string>("");
+
+  const handleCycleChange = (id: number, name: string) => {
+    setSelectedCycleId(id);
+    setSelectedCycleName(name);
+  };
+
   return (
     <div className="pt-6">
       <div className="p-6 pb-0 m-0">
         <header className="flex justify-between items-center">
-          <h1 className="text-xl font-semibold">Ciclo 2024.2</h1>
-          <EvaluationCycleSelector currentCycle="2024.2" />
+          <h1 className="text-xl font-semibold">
+            {selectedCycleName ? `Ciclo ${selectedCycleName}` : "Selecione um ciclo"}
+          </h1>
+          <EvaluationCycleSelector currentCycle={selectedCycleName} onChange={handleCycleChange} />
         </header>
         <nav className="flex gap-20 pt-16 m-0 pl-10">
           {tabs.map(({ label, path }) => (
@@ -33,7 +44,7 @@ const ComparisonLayout = () => {
           ))}
         </nav>
       </div>
-      <Outlet />
+      <Outlet context={{ selectedCycleId, selectedCycleName }} /> {/* 👈 IMPORTANTE */}
     </div>
   );
 };

--- a/frontend/src/pages/collaborator/evaluation/ComparisonEvaluation.tsx
+++ b/frontend/src/pages/collaborator/evaluation/ComparisonEvaluation.tsx
@@ -1,32 +1,63 @@
 import { useEffect, useState } from "react";
+import { useOutletContext } from "react-router-dom";
 import EvaluationComparisonGroupList from "../../../components/ComparisonEvaluationForm/EvaluationComparisonGroupList";
-import type { TrackWithGroups } from "../../../types/selfEvaluation";
 import { useAuth } from "../../../context/AuthContext";
+import type { TrackWithGroups } from "../../../types/selfEvaluation";
+
+type OutletContextType = {
+  selectedCycleId: number | null;
+  selectedCycleName: string;
+};
 
 export default function ComparisonEvaluation() {
   const { token, user } = useAuth();
+  const { selectedCycleId } = useOutletContext<OutletContextType>();
   const [trackData, setTrackData] = useState<TrackWithGroups | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const fetchTrack = async () => {
       try {
-        const response = await fetch("http://localhost:3000/rh-criteria/tracks/with-criteria", {
+        const res = await fetch("http://localhost:3000/rh-criteria/tracks/with-criteria", {
           headers: { Authorization: `Bearer ${token}` },
         });
-        const data: TrackWithGroups[] = await response.json();
-
-        // Encontra a trilha do usuário
+        const data: TrackWithGroups[] = await res.json();
         const track = data.find((t) => t.id === user?.trackId);
         if (track) setTrackData(track);
       } catch (err) {
         console.error("Erro ao buscar dados da trilha:", err);
+      } finally {
+        setLoading(false);
       }
     };
 
     fetchTrack();
   }, [token, user?.trackId]);
 
-  if (!trackData) return <div>Carregando trilha...</div>;
+  if (loading) return <div className="bg-[#f1f1f1] h-screen w-full" />;
 
-  return <EvaluationComparisonGroupList trackData={trackData} cycleId={1} />;
+  if (!trackData)
+    return (
+      <div className="bg-[#f1f1f1] h-screen w-full p-3 flex items-center justify-center">
+        <p className="text-sm text-gray-400 text-center">
+          Erro ao carregar sua trilha. Por favor, tente novamente.
+        </p>
+      </div>
+    );
+
+  if (!selectedCycleId)
+    return (
+      <div className="bg-[#f1f1f1] h-screen w-full p-3 flex items-center justify-center">
+        <p className="text-sm text-gray-400 text-start">
+          Selecione um ciclo para visualizar sua autoavaliação anterior.
+        </p>
+      </div>
+    );
+
+  return (
+    <EvaluationComparisonGroupList
+      cycleId={selectedCycleId}
+      trackData={trackData}
+    />
+  );
 }

--- a/frontend/src/pages/collaborator/evaluation/ComparisonEvaluation.tsx
+++ b/frontend/src/pages/collaborator/evaluation/ComparisonEvaluation.tsx
@@ -1,16 +1,37 @@
-import EvaluationComparisonForm from "../../../components/ComparisonEvaluationForm/ComparisonEvaluationForm";
+import EvaluationComparisonGroupList from "../../../components/ComparisonEvaluationForm/EvaluationComparisonGroupList";
+import type { TrackWithGroups } from "../../../types/selfEvaluation";
+
+// isso virá do backend em breve, mas pode ser passado como prop
+const mockTrackData: TrackWithGroups = {
+  id: 1,
+  name: "Trilha Backend",
+  CriterionGroup: [
+    {
+      id: 10,
+      name: "Postura",
+      configuredCriteria: [
+        {
+          id: 101,
+          criterionId: 1,
+          mandatory: true,
+          criterion: {
+            id: 1,
+            name: "SENTIMENTO_DE_DONO",
+            generalDescription: "Desenvolve senso de responsabilidade",
+            active: true,
+            weight: 1,
+            displayName: "Sentimento de Dono",
+          },
+        },
+        // ...
+      ],
+    },
+    // outros grupos...
+  ],
+};
 
 export default function ComparisonEvaluation() {
-  const postureCriteria = [
-    { title: "Sentimento de Dono" },
-    { title: "Resiliência nas adversidades" },
-    { title: "Trabalho em equipe" },
-    { title: "Comunicação clara" },
-  ];
-
   return (
-    <div className="p-3 bg-[#f1f1f1]">
-      <EvaluationComparisonForm title="Critérios de Postura" criteria={postureCriteria} />
-    </div>
+    <EvaluationComparisonGroupList trackData={mockTrackData} cycleId={1} />
   );
 }

--- a/frontend/src/pages/collaborator/evaluation/SelfEvaluation.tsx
+++ b/frontend/src/pages/collaborator/evaluation/SelfEvaluation.tsx
@@ -3,17 +3,20 @@ import axios from "axios";
 import { useAuth } from "../../../context/AuthContext";
 import type { TrackWithGroups } from "../../../types/selfEvaluation";
 import SelfEvaluationGroupList from "../../../components/SelfEvaluationForm/SelfEvaluationGroupList";
+import { fetchActiveEvaluationCycle } from "../../../services/api"; // ajuste o caminho conforme sua estrutura
 
 export default function SelfEvaluationPage() {
   const { token, user } = useAuth();
   const [trackGroups, setTrackGroups] = useState<TrackWithGroups | null>(null);
   const [loading, setLoading] = useState(true);
-
-  const currentCycleId = 1;
+  const [cycleId, setCycleId] = useState<number | null>(null);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
+        const cycle = await fetchActiveEvaluationCycle();
+        setCycleId(cycle?.id || null);
+
         const res = await axios.get("http://localhost:3000/rh-criteria/tracks/with-criteria", {
           headers: { Authorization: `Bearer ${token}` },
         });
@@ -22,7 +25,7 @@ export default function SelfEvaluationPage() {
         const trackData = res.data.find((t: any) => t.id === userTrack);
         setTrackGroups(trackData || null);
       } catch (err) {
-        console.error("Erro ao carregar critérios agrupados:", err);
+        console.error("Erro ao carregar dados:", err);
       } finally {
         setLoading(false);
       }
@@ -35,13 +38,13 @@ export default function SelfEvaluationPage() {
     return <p className="text-center text-gray-500 mt-10">Carregando critérios...</p>;
   }
 
-  if (!trackGroups) {
-    return <p className="text-center text-gray-500 mt-10">Nenhum critério encontrado.</p>;
+  if (!trackGroups || !cycleId) {
+    return <p className="text-center text-gray-500 mt-10">Nenhum critério ou ciclo ativo encontrado.</p>;
   }
 
   return (
     <div className="p-3 bg-[#f1f1f1] mt-0">
-      <SelfEvaluationGroupList trackData={trackGroups} cycleId={currentCycleId} />
+      <SelfEvaluationGroupList trackData={trackGroups} cycleId={cycleId} />
     </div>
   );
 }

--- a/frontend/src/types/evaluationComparison.ts
+++ b/frontend/src/types/evaluationComparison.ts
@@ -1,21 +1,52 @@
-export interface ComparisonCriterion {
-  title: string;
-}
-
 export interface EvaluationComparisonItemProps {
   index: number;
   title: string;
-
   selfScore: number;
   finalScore: number;
-
-  setSelfScore: (value: number) => void;
-
   justification: string;
-  setJustification: (value: string) => void;
 }
 
-export interface EvaluationComparisonFormProps {
+export interface EvaluationComparisonItemData {
   title: string;
-  criteria: ComparisonCriterion[];
+  selfScore: number;
+  finalScore: number;
+  justification: string;
+}
+
+export interface SubmittedSelfEvaluationItem {
+  id: number;
+  criterionId: number;
+  score: number;
+  justification: string;
+  scoreDescription: string;
+  group: {
+    id: number;
+    name: string;
+  } | null;
+}
+export interface EvaluationComparisonItemProps {
+  index: number;
+  title: string;
+  selfScore: number;
+  finalScore: number;
+  justification: string;
+}
+
+export interface EvaluationComparisonItemData {
+  title: string;
+  selfScore: number;
+  finalScore: number;
+  justification: string;
+}
+
+export interface SubmittedSelfEvaluationItem {
+  id: number;
+  criterionId: number;
+  score: number;
+  justification: string;
+  scoreDescription: string;
+  group: {
+    id: number;
+    name: string;
+  } | null;
 }


### PR DESCRIPTION
Refactored Layout:

- Moved the cycle selector dropdown (EvaluationCycleSelector) from the ComparisonEvaluation page to the ComparisonLayout to ensure it persists across tabs.

New Context Handling:

- Introduced useOutletContext in ComparisonEvaluation and similar pages to access the selected cycle ID and name from the layout.

improved API Integration:

- Updated EvaluationComparisonGroupList to use the correct route (/self-evaluation?cycleId=...) and fetch only the relevant responses for the selected cycle.

UI Enhancements:

- Displayed a styled empty state card when no cycle is selected, following the visual standard of the “mentor not found” message.
- Improved consistency in error/loading messages across evaluation pages.

Fixes:

- Fixed route logic to avoid useOutletContext being undefined on first load.
- Corrected enum usage for fetching closed cycles (excluding current active cycle).

